### PR TITLE
Update optional notifications from email to Pushcut

### DIFF
--- a/default/{{cookiecutter.project_short_name}}/README.md
+++ b/default/{{cookiecutter.project_short_name}}/README.md
@@ -44,9 +44,11 @@ To remove cluster results on your local machine, run `snakemake clean_cluster_re
 
 ## Be notified of build successes or fails
 
-As the execution of this workflow may take a while, you can be notified whenever the execution terminates either successfully or unsuccessfully. Notifications are sent by email. To activate notifications, add the email address of the recipient to the configuration key `email`. You can add the key to your configuration file, or you can run the workflow the following way to receive notifications:
+As the execution of this workflow may take a while, you can be notified whenever the execution terminates either successfully or unsuccessfully. Notifications are sent by the webservice [Pushcut](https://pushcut.io/) for which you need a free account. To activate notifications, add your Pushcut secret to the configuration using the configuration key `pushcut_secret`. You can add the key to your configuration file, or you can run the workflow the following way to receive notifications:
 
-    snakemake --config email=<your-email>
+    snakemake --config pushcut_secret=<your-secret>
+
+This workflow will then trigger the Pushcut notifications `snakemake_succeeded` and `snakemake_failed`.
 
 ## Run the tests
 

--- a/default/{{cookiecutter.project_short_name}}/Snakefile
+++ b/default/{{cookiecutter.project_short_name}}/Snakefile
@@ -1,4 +1,5 @@
 from snakemake.utils import min_version
+import requests
 PANDOC = "pandoc --filter pantable --filter pandoc-crossref --citeproc -f markdown+mark"
 
 configfile: "config/default.yaml"
@@ -9,24 +10,14 @@ min_version("8.20")
 
 {% if cookiecutter._add_cluster_infrastructure == True %}
 onstart:
-    shell("mkdir -p build/logs")
-    shell("""
-    if [ ! -d build/logs/slurm ] && [ -d .snakemake/slurm_logs ]; then
-        ln -s $PWD/.snakemake/slurm_logs build/logs/slurm
-    fi
-    """)
-    shell("""
-    if [ ! -d build/logs/snakemake ]; then
-        ln -s $PWD/.snakemake/log build/logs/snakemake
-    fi
-    """)
+    prepare_log_directories()
 {% endif %}
 onsuccess:
-    if "email" in config.keys():
-        shell("echo "" | mail -s '{{cookiecutter.project_short_name}} succeeded' {config[email]}")
+    if "pushcut_secret" in config.keys():
+        trigger_pushcut(event_name="snakemake_succeeded", secret=config["pushcut_secret"])
 onerror:
-    if "email" in config.keys():
-        shell("echo "" | mail -s '{{cookiecutter.project_short_name}} failed' {config[email]}")
+    if "pushcut_secret" in config.keys():
+        trigger_pushcut(event_name="snakemake_failed", secret=config["pushcut_secret"])
 
 rule all:
     message: "Run entire analysis and compile report."
@@ -142,3 +133,28 @@ rule test:
     output: "build/test.success"
     conda: "./envs/test.yaml"
     script: "./tests/test_runner.py"
+
+
+def trigger_pushcut(event_name: str, secret: str) -> None:
+    """Trigger a Pushcut notification."""
+    response = requests.post(
+            f'https://api.pushcut.io/{secret}/notifications/{event_name}'
+    )
+    response.raise_for_status()
+
+
+{% if cookiecutter._add_cluster_infrastructure == True %}
+def prepare_log_directories() -> None:
+    """Create symlinks to Snakemake log directories."""
+    shell("mkdir -p build/logs")
+    shell("""
+    if [ ! -d build/logs/slurm ] && [ -d .snakemake/slurm_logs ]; then
+        ln -s $PWD/.snakemake/slurm_logs build/logs/slurm
+    fi
+    """)
+    shell("""
+    if [ ! -d build/logs/snakemake ]; then
+        ln -s $PWD/.snakemake/log build/logs/snakemake
+    fi
+    """)
+{% endif %}


### PR DESCRIPTION
Fixes #41.

Optional notifications so far have been sent with `mail`. While very convenient, this relies on configuration outside the workflow that often is out-of-control of the user. Also, it relies on the executable being available.

For these two reasons, Pushcut is now replacing `mail`. Pushcut requires minimal configuration outside the workflow that is within control of the user and only needs the `requests` Python lib. On the downside, Pushcut is proprietary and only available on iOS and iPadOS. I did not find an alternative that is free, easy to use, and better available.