### PR TITLE
Update workflow to use conda

### DIFF
--- a/.github/workflows/reproduction.yaml
+++ b/.github/workflows/reproduction.yaml
@@ -30,7 +30,6 @@ jobs:
               with:
                 auto-update-conda: true
                 python-version: 3.11
-                mamba-version: 1.5.11
                 activate-environment: reproducible-research-project
                 environment-file: reproducible-research-project/environment.yaml
             - name: Reproduce results
@@ -65,7 +64,6 @@ jobs:
               with:
                 auto-update-conda: true
                 python-version: 3.11
-                mamba-version: 1.5.11
                 activate-environment: reproducible-research-project
                 environment-file: reproducible-research-project/environment.yaml
             - name: Reproduce results

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repository provides [cookiecutter](http://cookiecutter.readthedocs.io) templates for reproducible research projects. The templates do not attempt to be generic, but have a clear and opinionated focus.
 
-Projects build with these templates aim at full automation, and use `Python 3.11`, `mamba/conda`, `Git`, `Snakemake`, and `pandoc` to create a HTML and PDF report out of raw data, code, and `Markdown` text. Fork, clone, or download this repository on GitHub if you want to change any of these.
+Projects build with these templates aim at full automation, and use `Python 3.11`, `conda`, `Git`, `Snakemake`, and `pandoc` to create a HTML and PDF report out of raw data, code, and `Markdown` text. Fork, clone, or download this repository on GitHub if you want to change any of these.
 
 The template includes a few lines of code as a demo to allow you to create a report out of made-up simulation results right away. Read the `README.md` in the generated repository to see how.
 

--- a/cluster/{{cookiecutter.project_short_name}}/profiles/cluster/config.yaml
+++ b/cluster/{{cookiecutter.project_short_name}}/profiles/cluster/config.yaml
@@ -3,9 +3,7 @@ jobs: 999
 local-cores: 1
 cores: 10
 latency-wait: 60
-use-envmodules: True
-use-conda: True
-conda-frontend: mamba
+software-deployment-method: conda
 {% if cookiecutter.path_to_conda_envs != "Snakemake-default" %}
 conda-prefix: {{cookiecutter.path_to_conda_envs}}
 {% endif %}

--- a/default/{{cookiecutter.project_short_name}}/README.md
+++ b/default/{{cookiecutter.project_short_name}}/README.md
@@ -6,9 +6,9 @@ This repository contains the entire scientific project, including code and repor
 
 ## Getting ready
 
-You need [mamba](https://mamba.readthedocs.io/en/latest/) to run the analysis. Using mamba, you can create an environment from within you can run it:
+You need [conda](https://conda.org) to run the analysis. Using conda, you can create an environment from within you can run it:
 
-    mamba env create -f environment.yaml --no-default-packages
+    conda env create -f environment.yaml --no-default-packages
 
 ## Run the analysis
 

--- a/default/{{cookiecutter.project_short_name}}/environment.yaml
+++ b/default/{{cookiecutter.project_short_name}}/environment.yaml
@@ -4,7 +4,7 @@ channels:
     - bioconda
 dependencies:
     - python=3.11
-    - snakemake-minimal=8.20.5
+    - snakemake-minimal=8.20.6
     {% if cookiecutter._add_cluster_infrastructure == True %}
     - snakemake-executor-plugin-slurm=0.11.2
     {% endif %}

--- a/default/{{cookiecutter.project_short_name}}/profiles/default/config.yaml
+++ b/default/{{cookiecutter.project_short_name}}/profiles/default/config.yaml
@@ -1,5 +1,4 @@
-use-conda: True
-conda-frontend: mamba
+software-deployment-method: conda
 {% if cookiecutter.path_to_conda_envs != "Snakemake-default" %}
 conda-prefix: {{cookiecutter.path_to_conda_envs}}
 {% endif %}


### PR DESCRIPTION
Mamba has been deprecated by Snakemake in 8.20.6. Mamba is also not really necessary anymore in newer version of conda, as the fast dependency solver of mamba has been integrated into conda.

Fixes #40